### PR TITLE
chore: improve efficiency of ci pipeline

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -100,13 +100,25 @@ jobs:
         if: matrix.suite == 'cpp'
         run: |
           mkdir -p coverage-cpp
-          docker run --rm -v "$PWD/coverage-cpp:/cov" -u$(id -u):$(id -g) ghcr.io/${{ github.repository }}/process-command:test \
+          # Make sure the host directory is writable by appuser (UID 1000)
+          chmod 777 coverage-cpp  # or 755 if sufficient
+
+          docker run --rm \
+            -v "$PWD/coverage-cpp:/cov" \
+            ghcr.io/caragpe/command_listener/process-command:test \
             bash -c '
               set -e
-              cmake -B build -S . -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="--coverage"
-              cmake --build build -j$(nproc)
-              ctest --test-dir build -V
-              gcovr -r . --filter src/ --xml -o /cov/coverage.xml --html-details -o /cov/index.html'
+              # Build in a fresh, user-owned directory
+              mkdir -p /tmp/test-build
+              cd /tmp/test-build
+
+              cmake /app -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="--coverage"
+              cmake --build . -j$(nproc)
+              ctest -V
+
+              # Generate coverage and output to /cov (mounted volume)
+              gcovr -r /app --filter /app/src/ --xml -o /cov/coverage.xml --html-details -o /cov/index.html
+            '
 
       - name: Upload C++ coverage → Codecov
         if: matrix.suite == 'cpp'
@@ -128,12 +140,17 @@ jobs:
         if: matrix.suite == 'python'
         run: |
           mkdir -p test-reports
-          docker run --rm -v "$PWD/test-reports:/reports" -u$(id -u):$(id -g) ghcr.io/${{ github.repository }}/process-command:test \
+          chmod 777 test-reports
+
+          docker run --rm \
+            -v "$PWD/test-reports:/reports" \
+            ghcr.io/caragpe/command_listener/process-command:test \
             bash -c '
               set -e
-              python3 -m coverage run -m pytest python/tests --junitxml=/reports/junit.xml
-              python3 -m coverage xml  -o /reports/coverage.xml
-              python3 -m coverage html -d /reports/htmlcov'
+              cd /app/python
+              python3 -m coverage run -m pytest tests --junitxml=/reports/junit.xml
+              python3 -m coverage xml -o /reports/coverage.xml
+              python3 -m coverage html -d /reports/htmlcov
 
       - name: Upload Python coverage → Codecov
         if: matrix.suite == 'python'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -151,6 +151,7 @@ jobs:
               python3 -m coverage run -m pytest tests --junitxml=/reports/junit.xml
               python3 -m coverage xml -o /reports/coverage.xml
               python3 -m coverage html -d /reports/htmlcov
+            '
 
       - name: Upload Python coverage → Codecov
         if: matrix.suite == 'python'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ concurrency:
 
 permissions:
   contents: read
-  packages: write # Required to push/pull from GHCR
+  # No 'packages' needed — we're using Docker Hub, not GHCR
 
 jobs:
   build:
@@ -21,36 +21,27 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract Docker metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ghcr.io/${{ github.repository }}/process-command
-          tags: |
-            type=raw,value=test
-
-      - name: Build and push Docker image
+      - name: Build and push Docker image to Docker Hub
         uses: docker/build-push-action@v5
         with:
           context: .
           target: test
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/process-command:test
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
   lint:
-    name: Linting (C++ and Python)
+    name: Lint (C++ and Python)
     needs: build
     strategy:
       matrix:
@@ -59,26 +50,25 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Log in to GHCR
+      - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Pull test image
-        run: docker pull ghcr.io/${{ github.repository }}/process-command:test
+      - name: Pull test image from Docker Hub
+        run: docker pull ${{ secrets.DOCKERHUB_USERNAME }}/process-command:test
 
       - name: Run C++ linter
         if: matrix.tool == 'cpp'
-        run: docker run --rm ghcr.io/${{ github.repository }}/process-command:test make -C build check-format
+        run: docker run --rm ${{ secrets.DOCKERHUB_USERNAME }}/process-command:test make -C build check-format
 
       - name: Run Python linter
         if: matrix.tool == 'python'
-        run: docker run --rm ghcr.io/${{ github.repository }}/process-command:test flake8 python/ --count --show-source --statistics
+        run: docker run --rm ${{ secrets.DOCKERHUB_USERNAME }}/process-command:test flake8 python/ --count --show-source --statistics
 
   test:
-    name: Testing (C++ and Python)
+    name: Test (C++ and Python)
     needs: build
     strategy:
       fail-fast: false
@@ -88,38 +78,32 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Log in to GHCR
+      - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Pull test image
-        run: docker pull ghcr.io/${{ github.repository }}/process-command:test
+      - name: Pull test image from Docker Hub
+        run: docker pull ${{ secrets.DOCKERHUB_USERNAME }}/process-command:test
 
       # ---------- C++ ----------
       - name: C++ tests & coverage
         if: matrix.suite == 'cpp'
         run: |
           mkdir -p coverage-cpp
-          # Make sure the host directory is writable by appuser (UID 1000)
-          chmod 777 coverage-cpp  # or 755 if sufficient
+          chmod 777 coverage-cpp  # Ensure container user can write
 
           docker run --rm \
             -v "$PWD/coverage-cpp:/cov" \
-            ghcr.io/caragpe/command_listener/process-command:test \
+            ${{ secrets.DOCKERHUB_USERNAME }}/process-command:test \
             bash -c '
               set -e
-              # Build in a fresh, user-owned directory
               mkdir -p /tmp/test-build
               cd /tmp/test-build
-
               cmake /app -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="--coverage"
               cmake --build . -j$(nproc)
               ctest -V
-
-              # Generate coverage and output to /cov (mounted volume)
               gcovr -r /app --filter /app/src/ --xml -o /cov/coverage.xml --html-details -o /cov/index.html
             '
 
@@ -147,7 +131,7 @@ jobs:
 
           docker run --rm \
             -v "$PWD/test-reports:/reports" \
-            ghcr.io/caragpe/command_listener/process-command:test \
+            ${{ secrets.DOCKERHUB_USERNAME }}/process-command:test \
             bash -c '
               set -e
               cd /app/python
@@ -178,15 +162,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Log in to GHCR
+      - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Pull test image
-        run: docker pull ghcr.io/${{ github.repository }}/process-command:test
+      - name: Pull test image from Docker Hub
+        run: docker pull ${{ secrets.DOCKERHUB_USERNAME }}/process-command:test
 
       - name: Run example
-        run: docker run --rm ghcr.io/${{ github.repository }}/process-command:test
+        run: docker run --rm ${{ secrets.DOCKERHUB_USERNAME }}/process-command:test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: CI
+name: Build-Lint-Test
 
 on:
   pull_request:
@@ -16,6 +16,7 @@ permissions:
 
 jobs:
   build:
+    name: Build and push Docker image
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -49,6 +50,7 @@ jobs:
           cache-to: type=gha,mode=max
 
   lint:
+    name: Linting (C++ and Python)
     needs: build
     strategy:
       matrix:
@@ -76,6 +78,7 @@ jobs:
         run: docker run --rm ghcr.io/${{ github.repository }}/process-command:test flake8 python/ --count --show-source --statistics
 
   test:
+    name: Testing (C++ and Python)
     needs: build
     strategy:
       fail-fast: false
@@ -168,7 +171,8 @@ jobs:
           name: python-test-results
           path: test-reports
 
-  example:
+  run-example:
+    name: Run example (smoke test)
     needs: build
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,53 +12,95 @@ concurrency:
 
 permissions:
   contents: read
+  packages: write # Required to push/pull from GHCR
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    outputs:
-      tag: process-command:test
     steps:
       - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/build-push-action@v5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}/process-command
+          tags: |
+            type=raw,value=test
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
         with:
           context: .
           target: test
-          tags: process-command:test
-          outputs: type=docker
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
   lint:
     needs: build
     strategy:
-      matrix: { tool: [cpp, python] }
+      matrix:
+        tool: [cpp, python]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
-      - run: docker run --rm process-command:test make -C build check-format
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull test image
+        run: docker pull ghcr.io/${{ github.repository }}/process-command:test
+
+      - name: Run C++ linter
         if: matrix.tool == 'cpp'
-      - run: docker run --rm process-command:test flake8 python/ --count --show-source --statistics
+        run: docker run --rm ghcr.io/${{ github.repository }}/process-command:test make -C build check-format
+
+      - name: Run Python linter
         if: matrix.tool == 'python'
+        run: docker run --rm ghcr.io/${{ github.repository }}/process-command:test flake8 python/ --count --show-source --statistics
 
   test:
     needs: build
     strategy:
       fail-fast: false
-      matrix: { suite: [cpp, python] }
+      matrix:
+        suite: [cpp, python]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull test image
+        run: docker pull ghcr.io/${{ github.repository }}/process-command:test
 
       # ---------- C++ ----------
       - name: C++ tests & coverage
         if: matrix.suite == 'cpp'
         run: |
           mkdir -p coverage-cpp
-          docker run --rm -v "$PWD/coverage-cpp:/cov" -u$(id -u):$(id -g) process-command:test \
+          docker run --rm -v "$PWD/coverage-cpp:/cov" -u$(id -u):$(id -g) ghcr.io/${{ github.repository }}/process-command:test \
             bash -c '
               set -e
               cmake -B build -S . -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="--coverage"
@@ -86,7 +128,7 @@ jobs:
         if: matrix.suite == 'python'
         run: |
           mkdir -p test-reports
-          docker run --rm -v "$PWD/test-reports:/reports" -u$(id -u):$(id -g) process-command:test \
+          docker run --rm -v "$PWD/test-reports:/reports" -u$(id -u):$(id -g) ghcr.io/${{ github.repository }}/process-command:test \
             bash -c '
               set -e
               python3 -m coverage run -m pytest python/tests --junitxml=/reports/junit.xml
@@ -113,5 +155,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
-      - run: docker run --rm process-command:test
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull test image
+        run: docker pull ghcr.io/${{ github.repository }}/process-command:test
+
+      - name: Run example
+        run: docker run --rm ghcr.io/${{ github.repository }}/process-command:test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,115 +1,117 @@
-name: Build_Format_and_Tests
+name: CI
 
 on:
   pull_request:
     branches: [main]
-    types: [opened, reopened, synchronize]
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
-  build-and-test:
+  build:
     runs-on: ubuntu-latest
-    env:
-      DOCKER_BUILDKIT: 1
-
+    outputs:
+      tag: process-command:test
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Cache Docker layers
-        uses: actions/cache@v3
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/build-push-action@v5
         with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
+          context: .
+          target: test
+          tags: process-command:test
+          outputs: type=docker
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
-      - name: Prepare local cache dir (if not restored)
-        run: mkdir -p /tmp/.buildx-cache
+  lint:
+    needs: build
+    strategy:
+      matrix: { tool: [cpp, python] }
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - run: docker run --rm process-command:test make -C build check-format
+        if: matrix.tool == 'cpp'
+      - run: docker run --rm process-command:test flake8 python/ --count --show-source --statistics
+        if: matrix.tool == 'python'
 
-      - name: Build Docker image with Buildx
-        run: |
-          docker buildx build \
-            --tag process-command:test \
-            --file Dockerfile \
-            --cache-from=type=local,src=/tmp/.buildx-cache \
-            --cache-to=type=local,dest=/tmp/.buildx-cache,mode=max \
-            --output type=docker \
-            .
+  test:
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix: { suite: [cpp, python] }
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
 
-      - name: Run C++ code linting
-        run: |
-          docker run --rm process-command:test \
-            bash -c "cd /app/build && cmake --build . --target check-format"
-
-      - name: Run Python code linting
-        run: |
-          docker run --rm process-command:test \
-            flake8 python/ --count --show-source --statistics
-
-      - name: Generate C++ coverage
+      # ---------- C++ ----------
+      - name: C++ tests & coverage
+        if: matrix.suite == 'cpp'
         run: |
           mkdir -p coverage-cpp
-          sudo chown 1000:1000 coverage-cpp
-          docker run --rm \
-            -v $(pwd)/coverage-cpp:/coverage \
-            process-command:test \
-            bash -lc "
-              cd /app
-              mkdir -p build &&             
-              cd build &&
-              cmake -S /app -B . \
-              -DCMAKE_BUILD_TYPE=Debug \
-              -DCMAKE_CXX_FLAGS='--coverage' \
-              -DCMAKE_EXE_LINKER_FLAGS='--coverage' &&
-              make && 
-              ctest -V &&
-              # Generate coverage excluding third-party and CMake artifacts
-              gcovr -r /app \
-                --filter '/app/src' \
-                --exclude 'build/_deps' \
-                --exclude 'build/CMakeFiles' \
-                --xml -o /coverage/coverage.xml &&
-              gcovr -r /app \
-                --filter '/app/src' \
-                --exclude 'build/_deps' \
-                --exclude 'build/CMakeFiles' \
-                --html --html-details -o /coverage/index.html
-            "
+          docker run --rm -v "$PWD/coverage-cpp:/cov" -u$(id -u):$(id -g) process-command:test \
+            bash -c '
+              set -e
+              cmake -B build -S . -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="--coverage"
+              cmake --build build -j$(nproc)
+              ctest --test-dir build -V
+              gcovr -r . --filter src/ --xml -o /cov/coverage.xml --html-details -o /cov/index.html'
 
-      - name: Upload C++ coverage
+      - name: Upload C++ coverage → Codecov
+        if: matrix.suite == 'cpp'
+        uses: codecov/codecov-action@v4
+        with:
+          file: ./coverage-cpp/coverage.xml
+          flags: cpp
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Upload C++ coverage folder (artifact)
+        if: matrix.suite == 'cpp'
         uses: actions/upload-artifact@v4
         with:
           name: cpp-coverage
           path: coverage-cpp
 
-      - name: Set up Python test reports directory
+      # ---------- Python ----------
+      - name: Python tests & coverage
+        if: matrix.suite == 'python'
         run: |
           mkdir -p test-reports
-          sudo chown 1000:1000 test-reports
-      - name: Run Python tests
-        run: |
-          docker run --rm \
-            -v "$(pwd)/test-reports:/app/test-reports" \
-            process-command:test \
-            bash -c 'set -e; \
-              python3 -m coverage run -m pytest python/tests --junitxml=/app/test-reports/test-results.xml; \
-              python3 -m coverage xml -o /app/test-reports/coverage.xml; \
-              python3 -m coverage html -d /app/test-reports/htmlcov;'
+          docker run --rm -v "$PWD/test-reports:/reports" -u$(id -u):$(id -g) process-command:test \
+            bash -c '
+              set -e
+              python3 -m coverage run -m pytest python/tests --junitxml=/reports/junit.xml
+              python3 -m coverage xml  -o /reports/coverage.xml
+              python3 -m coverage html -d /reports/htmlcov'
 
-      - name: Upload Python test results
+      - name: Upload Python coverage → Codecov
+        if: matrix.suite == 'python'
+        uses: codecov/codecov-action@v4
+        with:
+          file: ./test-reports/coverage.xml
+          flags: python
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Upload Python test-reports folder (artifact)
+        if: matrix.suite == 'python'
         uses: actions/upload-artifact@v4
         with:
           name: python-test-results
-          path: |
-            test-reports/test-results.xml
-            test-reports/coverage.xml
-            test-reports/htmlcov/
+          path: test-reports
 
-      - name: Run Python example
-        run: |
-          docker run --rm process-command:test
+  example:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - run: docker run --rm process-command:test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Certified base image (Ubuntu 22.04 LTS)
-FROM ubuntu:22.04
+FROM ubuntu:22.04 AS build
 
 # Prevent interactive prompts during build
 ENV DEBIAN_FRONTEND=noninteractive
@@ -37,6 +37,8 @@ RUN cd build \
 
 RUN mkdir -p ./python/build \
     && cp build/libprocess_command.so ./python/build/
+
+FROM build as test
 
 # After installing system Python
 RUN python3 -m venv /opt/venv


### PR DESCRIPTION
# Summary

- Re-architected CI into four parallel jobs for faster feedback and clearer log
- Switched to multi-stage Dockerfile (build → test) and GitHub Actions cache (type=gha) . Removes local tar/artifact dance and speeds up rebuilds
- Added matrix strategy for C++ & Python linting and testing
- Registry moved from GHCR to Docker Hub; image pushed once and pulled by downstream jobs